### PR TITLE
[config]Change the default serial port for the Pi

### DIFF
--- a/examples/simpletest.py
+++ b/examples/simpletest.py
@@ -31,7 +31,7 @@ from Adafruit_BNO055 import BNO055
 # Create and configure the BNO sensor connection.  Make sure only ONE of the
 # below 'bno = ...' lines is uncommented:
 # Raspberry Pi configuration with serial UART and RST connected to GPIO 18:
-bno = BNO055.BNO055(serial_port='/dev/ttyAMA0', rst=18)
+bno = BNO055.BNO055(serial_port='/dev/serial0', rst=18)
 # BeagleBone Black configuration with default I2C connection (SCL=P9_19, SDA=P9_20),
 # and RST connected to pin P9_12:
 #bno = BNO055.BNO055(rst='P9_12')

--- a/examples/webgl_demo/server.py
+++ b/examples/webgl_demo/server.py
@@ -40,7 +40,7 @@ from Adafruit_BNO055 import BNO055
 # Create and configure the BNO sensor connection.  Make sure only ONE of the
 # below 'bno = ...' lines is uncommented:
 # Raspberry Pi configuration with serial UART and RST connected to GPIO 18:
-bno = BNO055.BNO055(serial_port='/dev/ttyAMA0', rst=18)
+bno = BNO055.BNO055(serial_port='/dev/serial0', rst=18)
 # BeagleBone Black configuration with default I2C connection (SCL=P9_19, SDA=P9_20),
 # and RST connected to pin P9_12:
 #bno = BNO055.BNO055(rst='P9_12')


### PR DESCRIPTION
- **Changes the default serial port on the Raspberry Pi setup.**  Since the Model 3, /dev/ttyACM0 is dedicated to the bluetooth chip, and /dev/ttyS0 is left for the general purpose serial port. For backward compatibility, /dev/serial0 links to /dev/ttyACM0 on pre-model 3 versions of the board, while it maps to /dev/ttyS0 on board starting with model 3
- **This requires up-to-date boards,** in order to get the correct /dev/serialX symlinks
