### PR TITLE
Updated typo of api in example comment

### DIFF
--- a/examples/simpletest.py
+++ b/examples/simpletest.py
@@ -73,7 +73,7 @@ while True:
           heading, roll, pitch, sys, gyro, accel, mag))
     # Other values you can optionally read:
     # Orientation as a quaternion:
-    #x,y,z,w = bno.read_quaterion()
+    #x,y,z,w = bno.read_quaternion()
     # Sensor temperature in degrees Celsius:
     #temp_c = bno.read_temp()
     # Magnetometer data (in micro-Teslas):


### PR DESCRIPTION
Updated a comment that had a typo in one of the methods names.  This hasn't affected execution of `simpletest.py` because it was in comment, but is useful to be correct if you are iterating off of `simpletest.py`  and relying on the commented API.
