### PR TITLE
Added accelerometer configuration methods

### DIFF
--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -60,11 +60,6 @@ BNO055_ACCEL_OPERATION_MODE_STANDBY         = 0b00000011
 BNO055_ACCEL_OPERATION_MODE_LOW_POWER_2     = 0b00000100
 BNO055_ACCEL_OPERATION_MODE_DEEP_SUSPEND    = 0b00000101
 
-# Accel Config Bitshifts
-BNO055_ACCEL_BANDWIDTH_BITSHIFT             = 2
-BNO055_ACCEL_OPERATION_MODE_BITSHIFT        = 5
-BNO055_ACCEL_G_RANGE_BITSHIFT               = 0
-
 # PAGE0 REGISTER DEFINITION START
 BNO055_CHIP_ID_ADDR                  = 0x00
 BNO055_ACCEL_REV_ID_ADDR             = 0x01
@@ -409,16 +404,24 @@ class BNO055(object):
 
         # Change to config mode
         self._config_mode()
+        # Set to Page 1
+        self._write_byte(BNO055_PAGE_ID_ADDR, 0x01)
+        # Sleep, allow change
+        time.sleep(0.02)
 
         # Send config byte to accel config register addr
         self._write_byte(BNO055_ACCEL_CFG_ADDR, byte & 0xFF)
         # Sleep for 20 ms to allow changes time to propagate
         time.sleep(0.02)
 
+        # Set back to page zero (default)
+        self._write_byte(BNO055_PAGE_ID_ADDR, 0x00)
+        time.sleep(0.02)
+
         # Return to operation mode
         self._operation_mode()
 
-    def begin(self, mode=OPERATION_MODE_NDOF):
+    def begin(self, mode=OPERATION_MODE_NDOF, **kwargs):
         """Initialize the BNO055 sensor.  Must be called once before any other
         BNO055 library functions.  Will return True if the BNO055 was
         successfully initialized, and False otherwise.

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -406,10 +406,16 @@ class BNO055(object):
         """Sets the acceleration config according to the datasheet (see set_mode)."""
         byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
 
+        # Change to config mode
+        self._config_mode()
+
         # Send config byte to accel config register addr
         self._write_byte(BNO055_ACCEL_CFG_ADDR, byte & 0xFF)
         # Sleep for 20 ms to allow changes time to propagate
         time.sleep(0.02)
+
+        # Return to operation mode
+        self._operation_mode()
 
     def begin(self, mode=OPERATION_MODE_NDOF):
         """Initialize the BNO055 sensor.  Must be called once before any other

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -406,6 +406,8 @@ class BNO055(object):
         """Sets the acceleration config according to the datasheet (see set_mode)."""
         byte = self._accel_g_range | (self._accel_bandwidth << 2) | (self._accel_operation_mode << 5)
         self._write_byte(BNO055_ACCEL_CFG_ADDR, byte & 0xFF)
+        # Sleep for 20 ms to allow changes time to propagate
+        time.sleep(0.02)
 
     def begin(self, mode=OPERATION_MODE_NDOF):
         """Initialize the BNO055 sensor.  Must be called once before any other

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -401,8 +401,8 @@ class BNO055(object):
 
     def _update_accel_config(self):
         """Sets the acceleration config according to the datasheet (see set_mode)."""
-        # byte = self._accel_g_range | (self._accel_bandwidth << 2) | (self._accel_operation_mode << 5)
-        byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
+        byte = self._accel_g_range | (self._accel_bandwidth << 2) | (self._accel_operation_mode << 5)
+        # byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
 
         # Change to config mode
         self._config_mode()

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -401,8 +401,8 @@ class BNO055(object):
 
     def _update_accel_config(self):
         """Sets the acceleration config according to the datasheet (see set_mode)."""
+        # pack bits into byte, see datasheet for more information.
         byte = self._accel_g_range | (self._accel_bandwidth << 2) | (self._accel_operation_mode << 5)
-        # byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
 
         # Change to config mode
         self._config_mode()

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -404,8 +404,6 @@ class BNO055(object):
         # byte = self._accel_g_range | (self._accel_bandwidth << 2) | (self._accel_operation_mode << 5)
         byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
 
-        # Change to config mode
-        self._config_mode()
         # Set to Page 1
         self._write_byte(BNO055_PAGE_ID_ADDR, 0x01)
         # Sleep, allow change
@@ -420,9 +418,6 @@ class BNO055(object):
         self._write_byte(BNO055_PAGE_ID_ADDR, 0x00)
         time.sleep(0.02)
 
-        # Return to operation mode
-        self._operation_mode()
-
     def begin(self, mode=OPERATION_MODE_NDOF, **kwargs):
         """Initialize the BNO055 sensor.  Must be called once before any other
         BNO055 library functions.  Will return True if the BNO055 was
@@ -430,6 +425,17 @@ class BNO055(object):
         """
         # Save the desired normal operation mode.
         self._mode = mode
+
+        # Copy kwargs to config
+        if kwargs is not None:
+            for key, value in kwargs.items():
+                if key == 'accel_bandwidth':
+                    self._accel_bandwidth = value
+                elif key == 'accel_g_range':
+                    self._accel_g_range = value
+                elif key == 'accel_operation_mode':
+                    self._accel_operation_mode = value
+
         # First send a thow-away command and ignore any response or I2C errors
         # just to make sure the BNO is in a good state and ready to accept
         # commands (this seems to be necessary after a hard power down).
@@ -466,6 +472,11 @@ class BNO055(object):
         self._write_byte(BNO055_PWR_MODE_ADDR, POWER_MODE_NORMAL)
         # Default to internal oscillator.
         self._write_byte(BNO055_SYS_TRIGGER_ADDR, 0x0)
+
+        # Set accelerometer config
+        self._update_accel_config()
+
+
         # Enter normal operation mode.
         self._operation_mode()
         return True
@@ -481,45 +492,45 @@ class BNO055(object):
         # too).
         time.sleep(0.03)
 
-    def set_accel_g_range(self, g_range = BNO055_ACCEL_G_RANGE_4G):
-        """Sets the acceleration G-Range to the specified range. Available ranges:
-
-        BNO055_ACCEL_G_RANGE_2G
-        BNO055_ACCEL_G_RANGE_4G
-        BNO055_ACCEL_G_RANGE_8G
-        BNO055_ACCEL_G_RANGE_16G
-
-        """
-        self._accel_g_range = g_range
-        self._update_accel_config()
-
-    def set_accel_bandwidth(self, bandwidth =BNO055_ACCEL_BANDWIDTH_64Hz):
-        """Sets teh acceleration update bandwidth to the specified value. Available values:
-
-        BNO055_ACCEL_BANDWIDTH_8Hz
-        BNO055_ACCEL_BANDWIDTH_16Hz
-        BNO055_ACCEL_BANDWIDTH_32Hz
-        BNO055_ACCEL_BANDWIDTH_64Hz
-        BNO055_ACCEL_BANDWIDTH_128Hz
-        BNO055_ACCEL_BANDWIDTH_256Hz
-        BNO055_ACCEL_BANDWIDTH_512Hz
-        BNO055_ACCEL_BANDWIDTH_1024Hz
-        """
-        self._accel_bandwidth = bandwidth
-        self._update_accel_config()
-
-    def set_accel_operation_mode(self, mode = BNO055_ACCEL_OPERATION_MODE_NORMAL):
-        """Sets the acceleration operation to the specified mode. Available modes:
-
-        BNO055_ACCEL_OPERATION_MODE_NORMAL
-        BNO055_ACCEL_OPERATION_MODE_SUSPEND
-        BNO055_ACCEL_OPERATION_MODE_LOW_POWER_1
-        BNO055_ACCEL_OPERATION_MODE_STANDBY
-        BNO055_ACCEL_OPERATION_MODE_LOW_POWER_2
-        BNO055_ACCEL_OPERATION_MODE_DEEP_SUSPEND
-        """
-        self._accel_operation_mode = mode
-        self._update_accel_config()
+    # def set_accel_g_range(self, g_range = BNO055_ACCEL_G_RANGE_4G):
+    #     """Sets the acceleration G-Range to the specified range. Available ranges:
+    #
+    #     BNO055_ACCEL_G_RANGE_2G
+    #     BNO055_ACCEL_G_RANGE_4G
+    #     BNO055_ACCEL_G_RANGE_8G
+    #     BNO055_ACCEL_G_RANGE_16G
+    #
+    #     """
+    #     self._accel_g_range = g_range
+    #     self._update_accel_config()
+    #
+    # def set_accel_bandwidth(self, bandwidth =BNO055_ACCEL_BANDWIDTH_64Hz):
+    #     """Sets teh acceleration update bandwidth to the specified value. Available values:
+    #
+    #     BNO055_ACCEL_BANDWIDTH_8Hz
+    #     BNO055_ACCEL_BANDWIDTH_16Hz
+    #     BNO055_ACCEL_BANDWIDTH_32Hz
+    #     BNO055_ACCEL_BANDWIDTH_64Hz
+    #     BNO055_ACCEL_BANDWIDTH_128Hz
+    #     BNO055_ACCEL_BANDWIDTH_256Hz
+    #     BNO055_ACCEL_BANDWIDTH_512Hz
+    #     BNO055_ACCEL_BANDWIDTH_1024Hz
+    #     """
+    #     self._accel_bandwidth = bandwidth
+    #     self._update_accel_config()
+    #
+    # def set_accel_operation_mode(self, mode = BNO055_ACCEL_OPERATION_MODE_NORMAL):
+    #     """Sets the acceleration operation to the specified mode. Available modes:
+    #
+    #     BNO055_ACCEL_OPERATION_MODE_NORMAL
+    #     BNO055_ACCEL_OPERATION_MODE_SUSPEND
+    #     BNO055_ACCEL_OPERATION_MODE_LOW_POWER_1
+    #     BNO055_ACCEL_OPERATION_MODE_STANDBY
+    #     BNO055_ACCEL_OPERATION_MODE_LOW_POWER_2
+    #     BNO055_ACCEL_OPERATION_MODE_DEEP_SUSPEND
+    #     """
+    #     self._accel_operation_mode = mode
+    #     self._update_accel_config()
 
     def get_revision(self):
         """Return a tuple with revision information about the BNO055 chip.  Will

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -61,9 +61,9 @@ BNO055_ACCEL_OPERATION_MODE_LOW_POWER_2     = 0b00000100
 BNO055_ACCEL_OPERATION_MODE_DEEP_SUSPEND    = 0b00000101
 
 # Accel Config Bitshifts
-BNO055_ACCEL_OPERATION_MODE_BITSHIFT        = 0
-BNO055_ACCEL_BANDWIDTH_BITSHIFT             = 3
-BNO055_ACCEL_G_RANGE_BITSHIFT               = 6
+BNO055_ACCEL_BANDWIDTH_BITSHIFT             = 2
+BNO055_ACCEL_OPERATION_MODE_BITSHIFT        = 5
+BNO055_ACCEL_G_RANGE_BITSHIFT               = 0
 
 # PAGE0 REGISTER DEFINITION START
 BNO055_CHIP_ID_ADDR                  = 0x00
@@ -404,7 +404,8 @@ class BNO055(object):
 
     def _update_accel_config(self):
         """Sets the acceleration config according to the datasheet (see set_mode)."""
-        byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
+        byte = self._accel_g_range | (self._accel_bandwidth << 2) | (self._accel_operation_mode << 5)
+        # byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
 
         # Change to config mode
         self._config_mode()

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -404,6 +404,8 @@ class BNO055(object):
         # byte = self._accel_g_range | (self._accel_bandwidth << 2) | (self._accel_operation_mode << 5)
         byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
 
+        # Change to config mode
+        self._config_mode()
         # Set to Page 1
         self._write_byte(BNO055_PAGE_ID_ADDR, 0x01)
         # Sleep, allow change
@@ -418,6 +420,9 @@ class BNO055(object):
         self._write_byte(BNO055_PAGE_ID_ADDR, 0x00)
         time.sleep(0.02)
 
+        # Return to operation mode
+        self._operation_mode()
+
     def begin(self, mode=OPERATION_MODE_NDOF, **kwargs):
         """Initialize the BNO055 sensor.  Must be called once before any other
         BNO055 library functions.  Will return True if the BNO055 was
@@ -425,17 +430,6 @@ class BNO055(object):
         """
         # Save the desired normal operation mode.
         self._mode = mode
-
-        # Copy kwargs to config
-        if kwargs is not None:
-            for key, value in kwargs.items():
-                if key == 'accel_bandwidth':
-                    self._accel_bandwidth = value
-                elif key == 'accel_g_range':
-                    self._accel_g_range = value
-                elif key == 'accel_operation_mode':
-                    self._accel_operation_mode = value
-
         # First send a thow-away command and ignore any response or I2C errors
         # just to make sure the BNO is in a good state and ready to accept
         # commands (this seems to be necessary after a hard power down).
@@ -472,11 +466,6 @@ class BNO055(object):
         self._write_byte(BNO055_PWR_MODE_ADDR, POWER_MODE_NORMAL)
         # Default to internal oscillator.
         self._write_byte(BNO055_SYS_TRIGGER_ADDR, 0x0)
-
-        # Set accelerometer config
-        self._update_accel_config()
-
-
         # Enter normal operation mode.
         self._operation_mode()
         return True
@@ -492,45 +481,45 @@ class BNO055(object):
         # too).
         time.sleep(0.03)
 
-    # def set_accel_g_range(self, g_range = BNO055_ACCEL_G_RANGE_4G):
-    #     """Sets the acceleration G-Range to the specified range. Available ranges:
-    #
-    #     BNO055_ACCEL_G_RANGE_2G
-    #     BNO055_ACCEL_G_RANGE_4G
-    #     BNO055_ACCEL_G_RANGE_8G
-    #     BNO055_ACCEL_G_RANGE_16G
-    #
-    #     """
-    #     self._accel_g_range = g_range
-    #     self._update_accel_config()
-    #
-    # def set_accel_bandwidth(self, bandwidth =BNO055_ACCEL_BANDWIDTH_64Hz):
-    #     """Sets teh acceleration update bandwidth to the specified value. Available values:
-    #
-    #     BNO055_ACCEL_BANDWIDTH_8Hz
-    #     BNO055_ACCEL_BANDWIDTH_16Hz
-    #     BNO055_ACCEL_BANDWIDTH_32Hz
-    #     BNO055_ACCEL_BANDWIDTH_64Hz
-    #     BNO055_ACCEL_BANDWIDTH_128Hz
-    #     BNO055_ACCEL_BANDWIDTH_256Hz
-    #     BNO055_ACCEL_BANDWIDTH_512Hz
-    #     BNO055_ACCEL_BANDWIDTH_1024Hz
-    #     """
-    #     self._accel_bandwidth = bandwidth
-    #     self._update_accel_config()
-    #
-    # def set_accel_operation_mode(self, mode = BNO055_ACCEL_OPERATION_MODE_NORMAL):
-    #     """Sets the acceleration operation to the specified mode. Available modes:
-    #
-    #     BNO055_ACCEL_OPERATION_MODE_NORMAL
-    #     BNO055_ACCEL_OPERATION_MODE_SUSPEND
-    #     BNO055_ACCEL_OPERATION_MODE_LOW_POWER_1
-    #     BNO055_ACCEL_OPERATION_MODE_STANDBY
-    #     BNO055_ACCEL_OPERATION_MODE_LOW_POWER_2
-    #     BNO055_ACCEL_OPERATION_MODE_DEEP_SUSPEND
-    #     """
-    #     self._accel_operation_mode = mode
-    #     self._update_accel_config()
+    def set_accel_g_range(self, g_range = BNO055_ACCEL_G_RANGE_4G):
+        """Sets the acceleration G-Range to the specified range. Available ranges:
+
+        BNO055_ACCEL_G_RANGE_2G
+        BNO055_ACCEL_G_RANGE_4G
+        BNO055_ACCEL_G_RANGE_8G
+        BNO055_ACCEL_G_RANGE_16G
+
+        """
+        self._accel_g_range = g_range
+        self._update_accel_config()
+
+    def set_accel_bandwidth(self, bandwidth =BNO055_ACCEL_BANDWIDTH_64Hz):
+        """Sets teh acceleration update bandwidth to the specified value. Available values:
+
+        BNO055_ACCEL_BANDWIDTH_8Hz
+        BNO055_ACCEL_BANDWIDTH_16Hz
+        BNO055_ACCEL_BANDWIDTH_32Hz
+        BNO055_ACCEL_BANDWIDTH_64Hz
+        BNO055_ACCEL_BANDWIDTH_128Hz
+        BNO055_ACCEL_BANDWIDTH_256Hz
+        BNO055_ACCEL_BANDWIDTH_512Hz
+        BNO055_ACCEL_BANDWIDTH_1024Hz
+        """
+        self._accel_bandwidth = bandwidth
+        self._update_accel_config()
+
+    def set_accel_operation_mode(self, mode = BNO055_ACCEL_OPERATION_MODE_NORMAL):
+        """Sets the acceleration operation to the specified mode. Available modes:
+
+        BNO055_ACCEL_OPERATION_MODE_NORMAL
+        BNO055_ACCEL_OPERATION_MODE_SUSPEND
+        BNO055_ACCEL_OPERATION_MODE_LOW_POWER_1
+        BNO055_ACCEL_OPERATION_MODE_STANDBY
+        BNO055_ACCEL_OPERATION_MODE_LOW_POWER_2
+        BNO055_ACCEL_OPERATION_MODE_DEEP_SUSPEND
+        """
+        self._accel_operation_mode = mode
+        self._update_accel_config()
 
     def get_revision(self):
         """Return a tuple with revision information about the BNO055 chip.  Will

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -61,9 +61,9 @@ BNO055_ACCEL_OPERATION_MODE_LOW_POWER_2     = 0b00000100
 BNO055_ACCEL_OPERATION_MODE_DEEP_SUSPEND    = 0b00000101
 
 # Accel Config Bitshifts
-BNO055_ACCEL_BANDWIDTH_BITSHIFT = 2
-BNO055_ACCEL_OPERATION_MODE_BITSHIFT = 5
-BNO055_ACCEL_G_RANGE_BITSHIFT = 0
+BNO055_ACCEL_OPERATION_MODE_BITSHIFT        = 0
+BNO055_ACCEL_BANDWIDTH_BITSHIFT             = 3
+BNO055_ACCEL_G_RANGE_BITSHIFT               = 6
 
 # PAGE0 REGISTER DEFINITION START
 BNO055_CHIP_ID_ADDR                  = 0x00
@@ -404,7 +404,7 @@ class BNO055(object):
 
     def _update_accel_config(self):
         """Sets the acceleration config according to the datasheet (see set_mode)."""
-        byte = self._accel_g_range | (self._accel_bandwidth << 2) | (self._accel_operation_mode << 5)
+        byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
         self._write_byte(BNO055_ACCEL_CFG_ADDR, byte & 0xFF)
         # Sleep for 20 ms to allow changes time to propagate
         time.sleep(0.02)
@@ -467,7 +467,7 @@ class BNO055(object):
         # too).
         time.sleep(0.03)
 
-    def set_accel_g_range(self, g_range: int = BNO055_ACCEL_G_RANGE_4G):
+    def set_accel_g_range(self, g_range = BNO055_ACCEL_G_RANGE_4G):
         """Sets the acceleration G-Range to the specified range. Available ranges:
 
         BNO055_ACCEL_G_RANGE_2G
@@ -479,7 +479,7 @@ class BNO055(object):
         self._accel_g_range = g_range
         self._update_accel_config()
 
-    def set_accel_bandwidth(self, bandwidth: int = BNO055_ACCEL_BANDWIDTH_64Hz):
+    def set_accel_bandwidth(self, bandwidth =BNO055_ACCEL_BANDWIDTH_64Hz):
         """Sets teh acceleration update bandwidth to the specified value. Available values:
 
         BNO055_ACCEL_BANDWIDTH_8Hz
@@ -494,7 +494,7 @@ class BNO055(object):
         self._accel_bandwidth = bandwidth
         self._update_accel_config()
 
-    def set_accel_operation_mode(self, mode: int = BNO055_ACCEL_OPERATION_MODE_NORMAL):
+    def set_accel_operation_mode(self, mode = BNO055_ACCEL_OPERATION_MODE_NORMAL):
         """Sets the acceleration operation to the specified mode. Available modes:
 
         BNO055_ACCEL_OPERATION_MODE_NORMAL

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -260,6 +260,8 @@ class BNO055(object):
             time.sleep(0.65)
         self._serial = None
 
+        self._mode = OPERATION_MODE_NDOF
+
         self._accel_g_range = BNO055_ACCEL_G_RANGE_4G
         self._accel_bandwidth = BNO055_ACCEL_BANDWIDTH_64Hz
         self._accel_operation_mode = BNO055_ACCEL_OPERATION_MODE_NORMAL
@@ -399,8 +401,8 @@ class BNO055(object):
 
     def _update_accel_config(self):
         """Sets the acceleration config according to the datasheet (see set_mode)."""
-        byte = self._accel_g_range | (self._accel_bandwidth << 2) | (self._accel_operation_mode << 5)
-        # byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
+        # byte = self._accel_g_range | (self._accel_bandwidth << 2) | (self._accel_operation_mode << 5)
+        byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
 
         # Change to config mode
         self._config_mode()

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -423,7 +423,7 @@ class BNO055(object):
         # Return to operation mode
         self._operation_mode()
 
-    def begin(self, mode=OPERATION_MODE_NDOF, **kwargs):
+    def begin(self, mode=OPERATION_MODE_NDOF):
         """Initialize the BNO055 sensor.  Must be called once before any other
         BNO055 library functions.  Will return True if the BNO055 was
         successfully initialized, and False otherwise.

--- a/Adafruit_BNO055/BNO055.py
+++ b/Adafruit_BNO055/BNO055.py
@@ -405,6 +405,8 @@ class BNO055(object):
     def _update_accel_config(self):
         """Sets the acceleration config according to the datasheet (see set_mode)."""
         byte = self._accel_operation_mode | (self._accel_bandwidth >> 3) | (self._accel_g_range >> 6)
+
+        # Send config byte to accel config register addr
         self._write_byte(BNO055_ACCEL_CFG_ADDR, byte & 0xFF)
         # Sleep for 20 ms to allow changes time to propagate
         time.sleep(0.02)


### PR DESCRIPTION
This code provides access to the accelerometer configuration, according to the specifications described by the BNO055 datasheet.. 

**Changes:**

New class members were added to keep track of the accelerometer configuration state (defaults are the defaults specified in the BNO055 datasheet), setter methods were added to provide access to the configuration parameters, and an internal/private method was added to send the accelerometer configuration state to the device (regardless of current operational mode -- the methods puts the IC into the configuration mode, updates the configuration, and sets it back to the previous operational mode). New constants/enums were also added to both provide a more accessible understanding of the parameter options, and also store the bits associated with said parameters.

The configuration upload/update method requires the IC be set to configuration mode, then sets the data page to page 0x01, followed by sending the packed configuration byte. Following this, the configuration page is set back to 0x00 (default), and the operational mode is returned to that stored by `self._mode`.

**Limitations:**

It may be my machine, but I cannot exceed an I2C update rate of ~260 Hz. This may be a limitation of the system more than the I2C interface implementation used by this library. The accelerometer configuration provides bandwidth/refresh-rates of up to ~1024 Hz (additionally 512, 256, and so on down to 8 Hz). The higher modes may be redundant on machines where the basal I2C rate is the limiting factor.

**Other Changes:**

I added the change at line 263 in order to prevent an exception being raised if the user calls any of the setter methods before the `begin()` method is called. For whatever reason, the default `self._mode` value is not set until the `begin()` method is called, though it really should be set in the `__init__()` method. The default value is the same specified by `begin()`.

If these changes are acceptable, I can also add configuration methods for the gyroscope and other sensor modules as well.
